### PR TITLE
feat: Add Docker support and configurable port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Stage 1: Build the Go application
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /app
+
+# Copy Go module files and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the server binary specifically
+# Change is on this line: ./cmd -> ./cmd/server
+RUN CGO_ENABLED=0 go build -o /app/potok-server ./cmd/server
+
+# Stage 2: Create the final, lightweight production image
+FROM alpine:latest
+
+WORKDIR /app
+
+# Copy the migrations folder, which is needed at runtime
+COPY --from=builder /app/migrations /migrations
+
+# Copy the compiled application binary from the builder stage
+COPY --from=builder /app/potok-server .
+
+# Expose the port the application runs on
+EXPOSE 8080
+
+# The command to run the application
+CMD ["/app/potok-server"]

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,25 +3,36 @@ package main
 import (
 	"fmt"
 	"log"
+	"os" // <-- Import the "os" package
 
 	"github.com/michaeltukdev/Potok/internal/api"
 	"github.com/michaeltukdev/Potok/internal/database"
 )
 
 func main() {
-	db, err := database.InitDB("potok.db")
-	if err != nil {
-		log.Fatal(err)
+	// Read DATABASE_PATH from environment, with a default if not set
+	dbPath := os.Getenv("DATABASE_PATH")
+	if dbPath == "" {
+		dbPath = "potok.db" // Default database path
 	}
-
+	db, err := database.InitDB(dbPath)
+	if err != nil {
+		log.Fatal("Failed to init DB:", err)
+	}
 	fmt.Println("Database running...")
 
 	if err := database.RunMigrations(db); err != nil {
 		log.Fatal("Failed to run migrations:", err)
 	}
-
 	fmt.Println("Migrations completed...")
 
-	fmt.Println("Starting HTTP server on :8080")
-	api.StartServer()
+	// Read PORT from environment, with a default if not set
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	
+	fmt.Println("Starting HTTP server on :" + port)
+	// Pass the port to the StartServer function
+	api.StartServer(port)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  app:
+    build: .
+    container_name: potok-server
+    ports:
+      - "8081:8080"
+    volumes:
+      - potok-database:/app/database
+      - potok-vault:/app/vault
+    environment:
+      - PORT=8080
+      - DATABASE_PATH=/app/database/potok.db
+
+volumes:
+  potok-database:
+  potok-vault:

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -16,7 +16,7 @@ import (
 	"github.com/michaeltukdev/Potok/internal/middleware"
 )
 
-func StartServer() {
+func StartServer(port string) { // <-- 1. Accept the port as an argument
 	r := mux.NewRouter()
 
 	api := r.PathPrefix("/").Subrouter()
@@ -35,8 +35,8 @@ func StartServer() {
 	// Authenticated user info
 	api.HandleFunc("/me", handleMe).Methods("GET")
 
-	log.Println("Starting server on :8080")
-	http.ListenAndServe(":8080", r)
+	log.Println("Starting server on :" + port) // <-- 2. Use the port variable in the log
+	http.ListenAndServe(":" + port, r)       // <-- 3. Use the port variable to start the server
 }
 
 // handleVaults returns all vaults for the authenticated user.

--- a/readme.md
+++ b/readme.md
@@ -90,3 +90,16 @@ Contributions are welcome! Please open issues or pull requests.
 - [spf13/cobra](https://github.com/spf13/cobra)
 - [zalando/go-keyring](https://github.com/zalando/go-keyring)
 - [fsnotify](https://github.com/fsnotify/fsnotify)
+
+
+
+## Running with Docker
+You can run the Potok server and its database with a single command using Docker.
+
+Make sure you have Docker and Docker Compose installed.
+
+From the root of the project, run the following command:
+
+<b>docker compose up --build</b>
+
+The server will be available at http://localhost:8080.


### PR DESCRIPTION
#4 

Changes:

Updated the server code to accept a PORT and DATABASE_PATH from environment variables, making it configurable.

Added a multi-stage Dockerfile that builds a minimal Go binary for production.

Created a docker-compose.yml to run the server and configure persistent volumes for the database and vault directories.

Updated the README.md with instructions on how to run the project using Docker.

How to Test:

Clone this branch.

Run docker compose up --build.

The server will be available on port 8080.